### PR TITLE
Issue::formArray expectes milestone as string

### DIFF
--- a/src/Adapter/GitLabIssueTracker.php
+++ b/src/Adapter/GitLabIssueTracker.php
@@ -85,6 +85,9 @@ class GitLabIssueTracker extends BaseIssueTracker
 
         return array_map(
             function ($issue) {
+                if (isset($issue['milestone']['title'])) {
+                    $issue['milestone'] = $issue['milestone']['title'];
+                }
                 return Issue::fromArray($this->client, $this->getCurrentProject(), $issue)->toArray();
             },
             $issues


### PR DESCRIPTION
```Issue::formArray``` expectes milestone as string. The GitLab API returns milestone as array with title, description and a few other properties.