### PR TITLE
Fixed Fatal error: Access to undeclared static property

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "gushphp/gush-gitlab-adapter",
     "description": "GitLab adapter for Gush",
     "require": {
-        "m4tthumphrey/php-gitlab-api": "*"
+        "m4tthumphrey/php-gitlab-api": "~7.11.0"
     },
     "license": "MIT",
     "authors": [

--- a/src/Model/MergeRequest.php
+++ b/src/Model/MergeRequest.php
@@ -23,7 +23,7 @@ class MergeRequest extends Model\MergeRequest
     {
         $cast = new static($mr->project, $mr->id, $mr->getClient());
 
-        foreach (static::$_properties as $property) {
+        foreach (static::$properties as $property) {
             $cast->$property = $mr->$property;
         }
 
@@ -62,7 +62,7 @@ class MergeRequest extends Model\MergeRequest
             ],
         ];
 
-        foreach (static::$_properties as $property) {
+        foreach (static::$properties as $property) {
             switch ($property) {
                 case 'id':
                     $mr['number'] = $this->$property;

--- a/src/Model/Project.php
+++ b/src/Model/Project.php
@@ -22,7 +22,7 @@ class Project extends Model\Project
     {
         $cast = new static($project->id, $project->getClient());
 
-        foreach (static::$_properties as $property) {
+        foreach (static::$properties as $property) {
             $cast->$property = $project->$property;
         }
 
@@ -41,7 +41,7 @@ class Project extends Model\Project
             'fork_origin' => null,
         ];
 
-        foreach (static::$_properties as $property) {
+        foreach (static::$properties as $property) {
             switch ($property) {
                 case 'owner':
                     $project['owner'] = $this->{$property}->username;

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -22,7 +22,7 @@ class User extends Model\User
     {
         $cast = new static($user->id, $user->getClient());
 
-        foreach (static::$_properties as $property) {
+        foreach (static::$properties as $property) {
             $cast->$property = $user->$property;
         }
 
@@ -33,7 +33,7 @@ class User extends Model\User
     {
         $user = [];
 
-        foreach (static::$_properties as $property) {
+        foreach (static::$properties as $property) {
             switch ($property) {
                 case 'username':
                     $user['login'] = $this->$property;


### PR DESCRIPTION
``static::$_properties`` has been renamed to ``static::$properties`` in https://github.com/m4tthumphrey/php-gitlab-api/commit/efca42ee19fb2c9ca9e63733a64ed06ba98c4205