### PR TITLE
Get project information by namespace and path

### DIFF
--- a/src/Adapter/GitLabAdapter.php
+++ b/src/Adapter/GitLabAdapter.php
@@ -74,37 +74,8 @@ trait GitLabAdapter
 
     protected function findProject($namespace, $projectName)
     {
-        $projects = $this->client->api('projects')->accessible(1, 100);
-        $currentModel = null;
-
-        // loop until we find a matching project or run-out of pages
-        while (true) {
-            foreach ($projects as $project) {
-                if ($project['path_with_namespace'] === $namespace.'/'.$projectName) {
-                    $currentModel = Model\Project::fromArray($this->client, $project);
-
-                    break 2;
-                }
-            }
-
-            $paginating = $this->getPagination($this->client->getHttpClient()->getLastResponse());
-
-            if (!isset($paginating['next'])) {
-                break;
-            }
-
-            $projects = $this->client->getHttpClient()->get(
-                substr($paginating['next'], strlen($this->configuration['base_url']))
-            )->getContent();
-        }
-
-        if (!$currentModel) {
-            throw new \RuntimeException(
-                sprintf('Could not find gitlab project id with %s/%s', $namespace, $projectName)
-            );
-        }
-
-        return $currentModel;
+        $project = $this->client->api('projects')->show($namespace . '/'. $projectName);
+        return Model\Project::fromArray($this->client, $project);
     }
 
     /**


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Fixed Tickets|   |
|License      |MIT|
                   

The GitLab API can resolve the project by id or namespace/path according to the documentation on http://doc.gitlab.com/ce/api/projects.html#get-single-project. I think it is a great performacne improvement. I think it breaks BC because older version of GitLab could not resolve project by path. The change was introduced in GitLab 5.0. I think its safe to discontinue support for GitLab 4.